### PR TITLE
Fix poggers_derive::create_entrypoint erroring

### DIFF
--- a/poggers-derive/src/lib.rs
+++ b/poggers-derive/src/lib.rs
@@ -117,7 +117,7 @@ pub fn create_entry(attr: TokenStream, item: TokenStream) -> TokenStream {
     let generated = quote! {
         #[no_mangle]
         extern "system" fn DllMain(
-            h_module : #curr_crate::exports::HINSTANCE,
+            h_module : #curr_crate::exports::HMODULE,
             reason : u32,
             _: *const ::std::ffi::c_void
         ) -> #curr_crate::exports::BOOL {

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -1,7 +1,7 @@
 /// this entire module is only used for [poggers_derive::create_entry]
 #[cfg(windows)]
 pub use windows::Win32::{
-    Foundation::{BOOL, HANDLE},
+    Foundation::{BOOL, HANDLE, HMODULE},
     System::{
         Console::{AllocConsole, FreeConsole},
         SystemServices::DLL_PROCESS_ATTACH,


### PR DESCRIPTION
@VilotStar did a booboo and oversaw this, dumb ass didn't use `pogggers_derive::create_entrypoint` so he couldn't even have saw this coming. 